### PR TITLE
Change Czech language code to accurate string

### DIFF
--- a/python-lib/translate.py
+++ b/python-lib/translate.py
@@ -159,6 +159,7 @@ SRC_TO_PYSBD_INDIRECT = {
     "ca": "es",
     "ceb": "en",  # Not same family, but Latin script
     "cs": "sk",
+    "cz": "sk",  # cz was an incorrect representation of Czech, which officially is 'cs' under ISO 639-1 - this is kept here for backwards compatibility
     "cy": "en",
     "et": "de",
     "ff": "en",  # Not same family, but Latin script

--- a/python-lib/translate.py
+++ b/python-lib/translate.py
@@ -158,7 +158,7 @@ SRC_TO_PYSBD_INDIRECT = {
     "bs": "bg",
     "ca": "es",
     "ceb": "en",  # Not same family, but Latin script
-    "cz": "sk",
+    "cs": "sk",
     "cy": "en",
     "et": "de",
     "ff": "en",  # Not same family, but Latin script


### PR DESCRIPTION
The language codes we use should follow the [ISO 639-1 standard](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes). 

Under this standard, Czech should be `cs`, instead of `cz`

This PR will fix issue #10

[sc-142021]