### PR TITLE
Correctly set GPU device

### DIFF
--- a/python-lib/translate.py
+++ b/python-lib/translate.py
@@ -287,7 +287,7 @@ class Translator:
         target_language: str,
         source_language: str = None,
         source_language_col: str = None,
-        device="CPU",
+        device="cpu",
         pretrained_model="facebook/m2m100_418M",
         revision="8005563f6b5843fb6820adf16bf2f91091dc97b6",
     ) -> None:

--- a/python-lib/translate.py
+++ b/python-lib/translate.py
@@ -238,7 +238,7 @@ MAX_INPUT_TOKENS = 300
 # ==============================================================================
 
 
-def get_device(device: str = "CPU") -> torch.device:
+def get_device(device: str = "cpu") -> torch.device:
     """
     Get torch device.
 
@@ -251,7 +251,7 @@ def get_device(device: str = "CPU") -> torch.device:
     Raises:
         ValueError: If GPU was selected, but not available
     """
-    if device == "GPU":
+    if device == "gpu":
         if torch.cuda.is_available():
             torch_device = torch.device("cuda")
         else:

--- a/tests/python/unit/test_translation.py
+++ b/tests/python/unit/test_translation.py
@@ -16,7 +16,7 @@ def test_m2m():
         input_column="translate_me",
         target_language="zh",
         source_language="en",
-        device="CPU",
+        device="cpu",
         pretrained_model="valhalla/m2m100_tiny_random",
         revision="337a4a691b7e14ad1668f5f4e481eaea6ce59ba1",
     )


### PR DESCRIPTION
[sc-135618]

We check if device == "GPU" in [translate.py](https://github.com/dataiku/dss-plugin-nlp-offline-translation/blob/master/python-lib/translate.py#L241). But in [recipe.py](https://github.com/dataiku/dss-plugin-nlp-offline-translation/blob/master/custom-recipes/nlp-offline-translation-translate/recipe.py#L26), the value of device can only be gpu or cpu. Since the value is lowercase and we check for GPU, this if condition is never true.

Note on testing:

This model appears to be super heavy on ram usage - using a gpu with 8gb of ram would consistently result in out of memory errors, even with a batch size of 1 

