### PR TITLE
Fix python support

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,37 @@
+# Git
+.git
+.gitignore
+.github
+
+# IDE
+.idea
+.vscode
+*.iml
+
+# Python
+__pycache__
+*.py[cod]
+*.egg-info
+.eggs
+*.egg
+.tox
+env/
+venv/
+.venv/
+.pytest_cache
+
+# Build artifacts
+dist/
+build/
+
+# Documentation
+*.md
+LICENSE
+
+# CI/CD
+Jenkinsfile
+Dockerfile
+
+# Other
+.DS_Store
+*.log

--- a/.github/workflows/auto-make.yml
+++ b/.github/workflows/auto-make.yml
@@ -2,16 +2,12 @@ name: Build
 
 on:  [push, pull_request]
 
-# A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
   make:
-    # The type of runner that the job will run on
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
-    # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
     - name: Checkout code
       uses: actions/checkout@v2
-    # Runs a single command using the runners shell
     - name: Make
       run: make plugin

--- a/.github/workflows/auto-unit-test.yml
+++ b/.github/workflows/auto-unit-test.yml
@@ -20,16 +20,13 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
-
-    - uses: actions/cache@v2
-      with:
-        path: ~/.cache/pip
-        key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
-        restore-keys: |
-          ${{ runner.os }}-pip-
+        cache: 'pip'
+        cache-dependency-path: |
+          tests/python/unit/requirements.txt
+          code-env/python/spec/requirements.txt
 
     - name: Run unit tests
       run: make unit-tests

--- a/.github/workflows/auto-unit-test.yml
+++ b/.github/workflows/auto-unit-test.yml
@@ -1,16 +1,24 @@
 name: Auto unit test
 
-on: [push, pull_request]
+on:
+  push:
+    branches: [main]  # Only run push on default branch after merge
+  pull_request:       # Run on all PRs
+
+# Cancel in-progress runs when a new commit is pushed
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   unit-tests:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v2
       with:

--- a/.github/workflows/auto-unit-test.yml
+++ b/.github/workflows/auto-unit-test.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        python-version: ["3.6", "3.7"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/auto-unit-test.yml
+++ b/.github/workflows/auto-unit-test.yml
@@ -14,6 +14,7 @@ jobs:
   unit-tests:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
 
@@ -28,5 +29,13 @@ jobs:
           tests/python/unit/requirements.txt
           code-env/python/spec/requirements.txt
 
-    - name: Run unit tests
-      run: make unit-tests
+    - name: Install dependencies
+      run: |
+        pip install -r tests/python/unit/requirements.txt
+        pip install -r code-env/python/spec/requirements.txt
+
+    - name: Run tests
+      env:
+        PYTHONPATH: python-lib
+      run: pytest tests/python/unit -v
+

--- a/.gitignore
+++ b/.gitignore
@@ -230,3 +230,6 @@ gradle-app.setting
 # # Work around https://youtrack.jetbrains.com/issue/IDEA-116898
 # gradle/wrapper/gradle-wrapper.properties
 .vscode/settings.json
+
+# IntelliJ
+.idea

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Version 1.2.0](https://github.com/dataiku/dss-plugin-nlp-offline-translation/releases/tag/v1.2.0) - Python supported versions update - 2026-01
+
+- ✨ Fix requirements for python 3.9, 3.10 and 3.11
+- ✨ Add support for python 3.12 and 3.13
+- ✨ Remove support for python 3.6, 3.7 and 3.8 
+
 ## [Version 1.1.1](https://github.com/dataiku/dss-plugin-nlp-offline-translation/releases/tag/v1.1.1) - Fix release - 2023-07
 
 - 👾 Fix Czech language encoding support

--- a/Makefile
+++ b/Makefile
@@ -51,3 +51,45 @@ tests: unit-tests integration-tests
 
 dist-clean:
 	rm -rf dist
+
+# Docker-based unit tests for Linux environment
+# Uses --platform linux/amd64 to ensure consistent behavior on Apple Silicon
+
+DOCKER_IMAGE_NAME=nlp-offline-translation
+DOCKER_PLATFORM=linux/amd64
+
+define run-docker-test
+	@echo "[START] Running unit tests in Docker with Python $(1)..."
+	@docker build \
+		--platform $(DOCKER_PLATFORM) \
+		--build-arg PYTHON_VERSION=$(1) \
+		-t $(DOCKER_IMAGE_NAME):py$(1) \
+		-f tests/docker/Dockerfile \
+		. && \
+	docker run --rm --platform $(DOCKER_PLATFORM) $(DOCKER_IMAGE_NAME):py$(1)
+	@echo "[DONE] Python $(1) tests completed"
+endef
+
+docker-test-py39:
+	$(call run-docker-test,3.9)
+
+docker-test-py310:
+	$(call run-docker-test,3.10)
+
+docker-test-py311:
+	$(call run-docker-test,3.11)
+
+docker-test-py312:
+	$(call run-docker-test,3.12)
+
+docker-test-py313:
+	$(call run-docker-test,3.13)
+
+docker-test-all: docker-test-py39 docker-test-py310 docker-test-py311 docker-test-py312 docker-test-py313
+	@echo "[SUCCESS] All Docker tests completed"
+
+docker-clean:
+	@echo "Removing Docker test images..."
+	@docker rmi -f $(DOCKER_IMAGE_NAME):py3.9 $(DOCKER_IMAGE_NAME):py3.10 $(DOCKER_IMAGE_NAME):py3.11 $(DOCKER_IMAGE_NAME):py3.12 $(DOCKER_IMAGE_NAME):py3.13 2>/dev/null || true
+	@echo "Docker images cleaned"
+

--- a/code-env/python/desc.json
+++ b/code-env/python/desc.json
@@ -1,11 +1,10 @@
 {
   "acceptedPythonInterpreters": [
-    "PYTHON36",
-    "PYTHON37",
-    "PYTHON38",
     "PYTHON39",
     "PYTHON310",
-    "PYTHON311"
+    "PYTHON311",
+    "PYTHON312",
+    "PYTHON313"
   ],
   "corePackagesSet": "AUTO",
   "forceConda": false,

--- a/code-env/python/spec/requirements.txt
+++ b/code-env/python/spec/requirements.txt
@@ -1,9 +1,7 @@
-sentencepiece==0.1.96; python_version <= '3.9'
-sentencepiece==0.1.98; python_version >= '3.10'
-torch==1.9; python_version <= '3.9'
-torch==1.13.1; python_version == '3.10'
-torch==2.0.0; python_version == '3.11'
-transformers==4.8.2; python_version <= '3.9'
-transformers==4.28.1; python_version >= '3.10'
+sentencepiece==0.2.1
+torch==2.7.1; python_version == '3.9'
+torch==2.10.0; python_version >= '3.10'
+transformers==4.57.6
+huggingface-hub==0.36.0
 pysbd==0.3.4
 

--- a/plugin.json
+++ b/plugin.json
@@ -3,7 +3,7 @@
     "version": "1.2.0",
     "meta": {
         "label": "Offline Translation",
-        "category": "Natural Language Processing",
+        "category": "NLP",
         "description": "Translate text offline across 100 languages",
         "author": "Dataiku (Niklas MUENNIGHOFF, Mehdi HAMOUMI, Krishna VADAKATTU)",
         "icon": "icon-dku-offline-translation",
@@ -11,8 +11,6 @@
         "supportLevel": "NOT_SUPPORTED",
         "url": "https://www.dataiku.com/product/plugins/nlp-offline-translation/",
         "tags": [
-            "Offline",
-            "Translation",
             "NLP"
         ]
     }

--- a/plugin.json
+++ b/plugin.json
@@ -1,6 +1,6 @@
 {
     "id": "nlp-offline-translation",
-    "version": "1.1.1",
+    "version": "1.2.0",
     "meta": {
         "label": "Offline Translation",
         "category": "Natural Language Processing",

--- a/tests/docker/Dockerfile
+++ b/tests/docker/Dockerfile
@@ -1,0 +1,33 @@
+ARG PYTHON_VERSION=3.12
+FROM python:${PYTHON_VERSION}-slim
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    build-essential \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /plugin
+
+# Copy requirements files first (for better layer caching)
+COPY code-env/python/spec/requirements.txt /plugin/requirements-plugin.txt
+COPY tests/python/unit/requirements.txt /plugin/requirements-test.txt
+
+# Install dependencies
+RUN pip install --upgrade pip && \
+    pip install --no-cache-dir -r requirements-test.txt && \
+    pip install --no-cache-dir -r requirements-plugin.txt
+
+# Copy source code and resources
+COPY python-lib/ /plugin/python-lib/
+COPY tests/python/unit/ /plugin/tests/python/unit/
+
+# Set environment variables
+ENV PYTHONPATH=/plugin/python-lib
+
+# Run tests with system info
+CMD echo "=== System Info ===" && \
+    echo "OS: $(cat /etc/os-release | grep PRETTY_NAME | cut -d'=' -f2)" && \
+    echo "Architecture: $(uname -m)" && \
+    echo "Python: $(python --version)" && \
+    echo "Pip: $(pip --version)" && \
+    echo "==================" && \
+    pytest tests/python/unit -v

--- a/tests/python/unit/requirements.txt
+++ b/tests/python/unit/requirements.txt
@@ -1,8 +1,11 @@
-sentencepiece==0.1.96
-torch==1.9
-transformers==4.8.2
-pytest==6.2.1
-allure-pytest==2.8.29
+# pytest - version constraints by Python version
+# pytest 6.x has AST compatibility issues with Python 3.10+
+# pytest 7.x dropped Python 3.6 support
+pytest>=6.2,<7; python_version == '3.6'
+pytest>=7.0,<8; python_version == '3.7'
+pytest>=7.0; python_version >= '3.8'
+
+allure-pytest>=2.8.29
 
 # Pandas - aligned with DSS 14.2 defaults
 pandas>=1.1,<1.2; python_version == '3.6'

--- a/tests/python/unit/requirements.txt
+++ b/tests/python/unit/requirements.txt
@@ -1,6 +1,11 @@
 sentencepiece==0.1.96
 torch==1.9
 transformers==4.8.2
-pandas>=1.0,<1.1
 pytest==6.2.1
 allure-pytest==2.8.29
+
+# Pandas - aligned with DSS 14.2 defaults
+pandas>=1.1,<1.2; python_version == '3.6'
+pandas>=1.3,<1.4; python_version == '3.7'
+pandas>=1.5,<1.6; python_version == '3.8'
+pandas>=2.2,<2.3; python_version >= '3.9'


### PR DESCRIPTION
- Fix requirements for python 3.9, 3.10 and 3.11
- Add support for python 3.12 and 3.13
- Remove support for python 3.6, 3.7 and 3.8

- Other changes
  - Fix/update GHA workflows
  - Add test utility to run unit tests within debian docker container example: `make docker-test-py312`